### PR TITLE
Simplify the output for `ModelVectorIndex.similar()`

### DIFF
--- a/wagtail_ai/index.py
+++ b/wagtail_ai/index.py
@@ -279,12 +279,10 @@ class ModelVectorIndex(VectorIndex[models.Model]):
         for embedding in instance_embeddings:
             similar_documents += self.backend_index.similarity_search(embedding.vector)
 
-        return list(
-            {
-                self._get_instance_from_response_document(doc)
-                for doc in similar_documents
-            }
-        )
+        return [
+            self._get_instance_from_response_document(doc)
+            for doc in similar_documents
+        ]
 
     def search(self, query: str, *, limit: int = 5):
         query_embedding = self.embedding_service.embeddings_for_strings([query])[0]


### PR DESCRIPTION
converting to set drops the ordering so you get funky results